### PR TITLE
Syntax: complete the name of scopes in beginCaptures

### DIFF
--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -16,10 +16,10 @@
 					"name": "punctuation.definition.markdown"
 				},
 				"5": {
-					"name": "fenced_code.block.language"
+					"name": "fenced_code.block.language.markdown"
 				},
 				"6": {
-					"name": "fenced_code.block.language.attributes"
+					"name": "fenced_code.block.language.attributes.markdown"
 				}
 			},
 			"endCaptures": {


### PR DESCRIPTION
Hi. If using the incomplete name is intentional, please close this PR.